### PR TITLE
CSS fix for Popular check icon width

### DIFF
--- a/src/components/Main.module.css
+++ b/src/components/Main.module.css
@@ -91,7 +91,6 @@
   transition: all 0.2s ease-out;
 }
 .points_text_list_item svg:hover {
-  /* --hover -> rgb(255, 89, 205) */
   background-color: rgba(204, 71, 164, 0.85) !important;
   transition: all 0.2s ease-out;
 }

--- a/src/components/Main.module.css
+++ b/src/components/Main.module.css
@@ -77,19 +77,21 @@
   gap: 1.2rem;
   cursor: pointer;
 }
+.points_text_list_item svg {
+  flex-shrink: 0;
+}
 .points_text_list_item span {
   background-color: rgba(255, 255, 255, 0.75);
   border-radius: 4px;
   flex-grow: 1;
   padding: 1.6rem;
 }
-
 .points_text_list_item span:hover {
   background-color: rgba(255, 255, 255, 0.9);
   transition: all 0.2s ease-out;
 }
 .points_text_list_item svg:hover {
-  /* rgb(255, 89, 205) */
+  /* --hover -> rgb(255, 89, 205) */
   background-color: rgba(204, 71, 164, 0.85) !important;
   transition: all 0.2s ease-out;
 }


### PR DESCRIPTION
On mobile mediaquery popular "check" icon square width with two lines of text was smaller and not square. 